### PR TITLE
u-boot-denx: turn on BeagleBone LEDs during boot

### DIFF
--- a/common-bsp/recipes-bsp/u-boot/u-boot-denx/0010-am335x_evm-enable-gpio-command.patch
+++ b/common-bsp/recipes-bsp/u-boot/u-boot-denx/0010-am335x_evm-enable-gpio-command.patch
@@ -1,0 +1,25 @@
+From 996e1ad4030e29c98dd4781e20307e07d5872171 Mon Sep 17 00:00:00 2001
+From: Jason Kridner <jdk@ti.com>
+Date: Thu, 4 Apr 2013 05:57:00 +0000
+Subject: [PATCH 1/2] am335x_evm: enable gpio command
+
+---
+ include/configs/am335x_evm.h |    2 +-
+ 1 files changed, 1 insertions(+), 1 deletions(-)
+
+diff --git a/include/configs/am335x_evm.h b/include/configs/am335x_evm.h
+index 5c9be89..14f172e 100644
+--- a/include/configs/am335x_evm.h
++++ b/include/configs/am335x_evm.h
+@@ -41,7 +41,7 @@
+ 
+ /* commands to include */
+ #include <config_cmd_default.h>
+-
++#define CONFIG_CMD_GPIO
+ #define CONFIG_CMD_ASKENV
+ #define CONFIG_VERSION_VARIABLE
+ 
+-- 
+1.7.8.6
+

--- a/common-bsp/recipes-bsp/u-boot/u-boot-denx/0011-am335x_evm-HACK-to-turn-on-BeagleBone-LEDs.patch
+++ b/common-bsp/recipes-bsp/u-boot/u-boot-denx/0011-am335x_evm-HACK-to-turn-on-BeagleBone-LEDs.patch
@@ -1,0 +1,43 @@
+From 6b4e776d7c9e532073357f8fd7d197bd28ce6507 Mon Sep 17 00:00:00 2001
+From: Jason Kridner <jdk@ti.com>
+Date: Thu, 4 Apr 2013 07:16:41 +0000
+Subject: [PATCH 2/2] am335x_evm: HACK to turn on BeagleBone LEDs
+
+* This might break non-BeagleBone platforms
+---
+ include/configs/am335x_evm.h |    4 ++++
+ 1 files changed, 4 insertions(+), 0 deletions(-)
+
+diff --git a/include/configs/am335x_evm.h b/include/configs/am335x_evm.h
+index 14f172e..391e6e1 100644
+--- a/include/configs/am335x_evm.h
++++ b/include/configs/am335x_evm.h
+@@ -143,6 +143,7 @@
+ #endif
+ 
+ #define CONFIG_BOOTCOMMAND \
++	"gpio set 53; " \
+ 	"i2c mw 0x24 1 0x3e; " \
+ 	"run findfdt; " \
+ 	"mmc dev 0; if mmc rescan ; then " \
+@@ -154,6 +155,7 @@
+ 	"fi;" \
+ 	"setenv bootpart ${mmcdev}:2;" \
+ 	"mmc dev ${mmcdev}; if mmc rescan; then " \
++		"gpio set 54; " \
+ 		"echo SD/MMC found on device ${mmcdev};" \
+ 		"if run loadbootenv; then " \
+ 			"echo Loaded environment from ${bootenv};" \
+@@ -163,7 +165,9 @@
+ 			"echo Running uenvcmd ...;" \
+ 			"run uenvcmd;" \
+ 		"fi;" \
++		"gpio set 55; " \
+ 		"if run loaduimage; then " \
++			"gpio set 56; " \
+ 			"run loadfdt;" \
+ 			"run mmcboot;" \
+ 		"fi;" \
+-- 
+1.7.8.6
+

--- a/common-bsp/recipes-bsp/u-boot/u-boot-denx_2013.01.bb
+++ b/common-bsp/recipes-bsp/u-boot/u-boot-denx_2013.01.bb
@@ -6,6 +6,7 @@ UBOOT_IMAGE = "u-boot-${MACHINE}-${PV}-${PR}.img"
 UBOOT_SYMLINK = "u-boot-${MACHINE}.img"
 
 PV = "2013.01+2013.04-rc1"
+PR = "r1"
 
 # No patches for other machines yet
 COMPATIBLE_MACHINE = "(beaglebone)"
@@ -23,6 +24,8 @@ SRC_URI = "git://git.denx.de/u-boot-arm.git \
            file://0007-beaglebone-Don-t-trigger-uboot-variable-lenght-limit.patch \
            file://0008-beaglebone-HACK-change-mmc-order-to-avoid-u-boot-cra.patch \
            file://0009-beaglebone-update-bootpart-variable-after-mmc-scan.patch \
+           file://0010-am335x_evm-enable-gpio-command.patch \
+           file://0011-am335x_evm-HACK-to-turn-on-BeagleBone-LEDs.patch \
            ${FWENV} \
           "
 


### PR DESCRIPTION
I'm a bit surprised this still seems to take a couple seconds to see the LED come on
