### PR TITLE
u-boot: add patch to enable CONFIG_SUPPORT_RAW_INITRD

### DIFF
--- a/common-bsp/recipes-bsp/u-boot/u-boot-denx/0013-beaglebone-enable-CONFIG_SUPPORT_RAW_INITRD-option.patch
+++ b/common-bsp/recipes-bsp/u-boot/u-boot-denx/0013-beaglebone-enable-CONFIG_SUPPORT_RAW_INITRD-option.patch
@@ -1,0 +1,25 @@
+From 35e3574d1789696aa0b1baecb51a3ec3c087c597 Mon Sep 17 00:00:00 2001
+From: Robert Nelson <robertcnelson@gmail.com>
+Date: Thu, 25 Apr 2013 13:50:35 -0500
+Subject: [PATCH 13/13] beaglebone: enable CONFIG_SUPPORT_RAW_INITRD option
+
+Signed-off-by: Robert Nelson <robertcnelson@gmail.com>
+---
+ include/configs/am335x_evm.h |    1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/include/configs/am335x_evm.h b/include/configs/am335x_evm.h
+index 9e39d00..04eaa8b 100644
+--- a/include/configs/am335x_evm.h
++++ b/include/configs/am335x_evm.h
+@@ -35,6 +35,7 @@
+ 
+ #define CONFIG_OF_LIBFDT
+ #define CONFIG_CMD_BOOTZ
++#define CONFIG_SUPPORT_RAW_INITRD
+ #define CONFIG_CMDLINE_TAG		/* enable passing of ATAGs */
+ #define CONFIG_SETUP_MEMORY_TAGS
+ #define CONFIG_INITRD_TAG
+-- 
+1.7.10.4
+

--- a/common-bsp/recipes-bsp/u-boot/u-boot-denx_2013.04.bb
+++ b/common-bsp/recipes-bsp/u-boot/u-boot-denx_2013.04.bb
@@ -26,6 +26,7 @@ SRC_URI = "git://git.denx.de/u-boot.git \
            file://0010-am335x_evm-enable-gpio-command.patch \
            file://0011-am335x_evm-HACK-to-turn-on-BeagleBone-LEDs.patch \
            file://0012-Fix-for-screen-rolling-when-video-played-back-in-bro.patch \
+           file://0013-beaglebone-enable-CONFIG_SUPPORT_RAW_INITRD-option.patch \
            ${FWENV} \
           "
 


### PR DESCRIPTION
Guys, enabling this in u-boot would make my ubuntu/debian images work out of the box with the factory images.. ;) I'm implementing a workaround for this weekend, for the initial launch beaglebone blacks...

Without:
reading initrd.net
9513834 bytes read in 1083 ms (8.4 MiB/s)
reading /dtbs/am335x-boneblack.dtb
23334 bytes read in 11 ms (2 MiB/s)
Wrong Ramdisk Image Format
Ramdisk image is corrupt or invalid
gpio: pin 55 (gpio 55) value is 1
*\* Invalid partition 2 **
U-Boot# 

Signed-off-by: Robert Nelson robertcnelson@gmail.com
