### PR TITLE
gadget-init: bypass broken MAC calculation when device tree mac-address ...

### DIFF
--- a/meta-beagleboard-extras/recipes-support/usb-gadget/gadget-init/g-ether-load.sh
+++ b/meta-beagleboard-extras/recipes-support/usb-gadget/gadget-init/g-ether-load.sh
@@ -35,13 +35,18 @@ function reverse_bytes()
 	echo ${New_addr}
 }
 
-DEVMEM_ADDR_LO=$(get_devmem 0x44e10638|bc)
-DEVMEM_ADDR_LO=$(reverse_bytes ${DEVMEM_ADDR_LO})
+mac_address="/proc/device-tree/ocp/ethernet@4a100000/slave@4a100300/mac-address"
+if [ -f ${mac_address} ] ; then
+	DEV_ADDR=$(hexdump -e '1/1 "%02X" ":"' ${mac_address} | sed 's/.$//')
+else
+	DEVMEM_ADDR_LO=$(get_devmem 0x44e10638|bc)
+	DEVMEM_ADDR_LO=$(reverse_bytes ${DEVMEM_ADDR_LO})
 
-DEVMEM_ADDR_HI=$(get_devmem 0x44e1063C)
-DEVMEM_ADDR_HI=$(reverse_bytes ${DEVMEM_ADDR_HI})
+	DEVMEM_ADDR_HI=$(get_devmem 0x44e1063C)
+	DEVMEM_ADDR_HI=$(reverse_bytes ${DEVMEM_ADDR_HI})
 
-DEV_ADDR=$(hex_to_mac_addr "${DEVMEM_ADDR_HI}${DEVMEM_ADDR_LO}")
+	DEV_ADDR=$(hex_to_mac_addr "${DEVMEM_ADDR_HI}${DEVMEM_ADDR_LO}")
+fi
 
 SERIAL_NUMBER=$(hexdump -e '8/1 "%c"' /sys/bus/i2c/devices/0-0050/eeprom -s 14 -n 2)-$(hexdump -e '8/1 "%c"' /sys/bus/i2c/devices/0-0050/eeprom -s 16 -n 12)
 ISBLACK=$(hexdump -e '8/1 "%c"' /sys/bus/i2c/devices/0-0050/eeprom -s 8 -n 4)


### PR DESCRIPTION
...is present

With my BeagleBone this script is mis-calculating the mac address from eeprom:

script: bc:6a:29:79:99:93
actual: bc:6a:29:79:ed:93

Replace calculation by direct hexdump of device tree mac-address:

debian@arm:~$ export mac_address="/proc/device-tree/ocp/ethernet@4a100000/slave@4a100300/mac-address"

debian@arm:~$ uname -a
Linux arm 3.8.12-bone17 #1 SMP Thu May 9 09:01:09 UTC 2013 armv7l GNU/Linux

debian@arm:~$ dmesg | grep cpsw
[    0.121903] cpsw.0: No hwaddr in dt. Using bc:6a:29:79:ed:91 from efuse
[    0.121936] cpsw.1: No hwaddr in dt. Using bc:6a:29:79:ed:93 from efuse
[    2.843867] cpsw 4a100000.ethernet: NAPI disabled
[   22.066903] net eth0: initializing cpsw version 1.12 (0)

debian@arm:~$ hexdump -e '1/1 "%02X" ":"' ${mac_address} | sed 's/.$//'
BC:6A:29:79:ED:93

Signed-off-by: Robert Nelson robertcnelson@gmail.com
