### PR TITLE
g-ether-load: fix mac address read

### DIFF
--- a/meta-beagleboard-extras/recipes-support/usb-gadget/gadget-init/g-ether-load.sh
+++ b/meta-beagleboard-extras/recipes-support/usb-gadget/gadget-init/g-ether-load.sh
@@ -37,7 +37,7 @@ function reverse_bytes()
 
 mac_address="/proc/device-tree/ocp/ethernet@4a100000/slave@4a100300/mac-address"
 if [ -f ${mac_address} ] ; then
-	DEV_ADDR=$(hexdump -e '1/1 "%02X" ":"' ${mac_address} | sed 's/.$//')
+	DEV_ADDR=$(hexdump -v -e '1/1 "%02X" ":"' ${mac_address} | sed 's/.$//')
 else
 	DEVMEM_ADDR_LO=$(get_devmem 0x44e10638|bc)
 	DEVMEM_ADDR_LO=$(reverse_bytes ${DEVMEM_ADDR_LO})


### PR DESCRIPTION
hexdump has a feature to replace repeated characters on output with an *,
use -v to disable this feature.

Thus

hexdump -e '1/1 "%02X" ":"' /proc/device-tree/ocp/ethernet@4a100000/slave@4a100200/mac-address
90:59:AF:5C:*
C5:debian@arm:~$

hexdump -v -e '1/1 "%02X" ":"' /proc/device-tree/ocp/ethernet@4a100000/slave@4a100200/mac-address
90:59:AF:5C:5C:C5:debian@arm:~$

Signed-off-by: Robert Nelson robertcnelson@gmail.com
